### PR TITLE
searches were always returning all nils

### DIFF
--- a/lib/chef/knife/batch.rb
+++ b/lib/chef/knife/batch.rb
@@ -112,7 +112,7 @@ class Batch < Chef::Knife
              q = Chef::Search::Query.new
              @action_nodes = q.search(:node, @name_args[0])[0]
              @action_nodes.each do |item|
-               i = format_for_display(item)[config[:attribute]]
+               i = format_for_display(item).values[0][config[:attribute]]
                r.push(i) unless i.nil?
              end
              r


### PR DESCRIPTION
My searches doing this

`knife batch "role:web" "hostname" -B 5 -W 10`

Where always returning nil values. Digging in I found it was returning a hash like

```
{"web10-eu.domain.com"=>{"fqdn"=>"web10-eu.domain.com"}}
```

Which wasn't getting pulled out. I don't know ruby that much so I just dumped out all the values and took the first one. Its now working for me

Maybe due to my chef version?

```
[root@chef01-east.domain.com /usr]# rpm -qa | grep chef
chef-server-11.1.6-1.el6.x86_64
chef-11.14.2-1.el6.x86_64
```
